### PR TITLE
Pick up Redis Address from Config

### DIFF
--- a/service/initialise.go
+++ b/service/initialise.go
@@ -66,8 +66,10 @@ func (e *Init) DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, versio
 	return &hc, nil
 }
 
-var GetRedisClient = func(ctx context.Context) (RedisClient, error) {
-	clientConfig := &disRedis.ClientConfig{}
+var GetRedisClient = func(ctx context.Context, cfg *config.Config) (RedisClient, error) {
+	clientConfig := &disRedis.ClientConfig{
+		Address: cfg.RedisAddress,
+	}
 	redisClient, err := disRedis.NewClient(ctx, clientConfig)
 
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -46,7 +46,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	// Get RedisClient client
 	var redisErr error
-	serviceList.RedisCli, redisErr = GetRedisClient(ctx)
+	serviceList.RedisCli, redisErr = GetRedisClient(ctx, cfg)
 
 	if redisErr != nil {
 		log.Fatal(ctx, "failed to initialise redis", redisErr)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 				return nil
 			},
 		}
-		service.GetRedisClient = func(ctx context.Context) (service.RedisClient, error) {
+		service.GetRedisClient = func(ctx context.Context, cfg *config.Config) (service.RedisClient, error) {
 			return redisClientMock, nil
 		}
 
@@ -94,7 +94,7 @@ func TestRun(t *testing.T) {
 			}
 			svcErrors := make(chan error, 1)
 			svcList := service.NewServiceList(initMock)
-			service.GetRedisClient = func(ctx context.Context) (service.RedisClient, error) {
+			service.GetRedisClient = func(ctx context.Context, cfg *config.Config) (service.RedisClient, error) {
 				return nil, errRedis
 			}
 


### PR DESCRIPTION
### What

Although the Redis Address was being set in the config, it was not actually being used by the Redirect Proxy service.

I've amended the function that creates the Redis client (GetRedisClient) so that it uses the Redis Address in the client config.

This will enable the dp-compose stacks, and possibly other services, to make use of the REDIS_ADDRESS environment variable.

### How to review

Sense check and make sure that the tests still pass.

### Who can review

Anyone but me.