### PR TITLE
Check URL based on path alone, not query

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -69,7 +69,7 @@ func (proxy *Proxy) redirectMiddleware(redisCli clients.Redis) mux.MiddlewareFun
 				return
 			}
 
-			redirectURL, err := proxy.checkRedirect(req.URL.String(), req.Context(), redisCli)
+			redirectURL, err := proxy.checkRedirect(req.URL.Path, req.Context(), redisCli)
 			if err == nil && redirectURL != "" {
 				// Redirect with 308 Permanent Redirect
 				http.Redirect(w, req, redirectURL, http.StatusPermanentRedirect)
@@ -90,7 +90,7 @@ func (proxy *Proxy) redirectMiddleware(redisCli clients.Redis) mux.MiddlewareFun
 
 // checkRedirect checks if a redirect exists in Redis
 func (proxy *Proxy) checkRedirect(checkURL string, ctx context.Context, redisClient clients.Redis) (string, error) {
-	// Get the redirect URL from Redis based on the incoming URL
+	// Get the redirect URL from Redis based on the incoming URL path
 	redirectURL, err := redisClient.GetValue(ctx, checkURL)
 	if err == disRedis.ErrKeyNotFound {
 		// If the key does not exist, return an empty string

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -119,6 +119,21 @@ func TestProxyHandleRequestWithRedirect(t *testing.T) {
 					So(parsedURL.Path, ShouldEqual, "/new-url")
 				})
 
+				Convey("When a request triggers a redirect with a query string", func() {
+					req, err := http.NewRequest("GET", "/old-url?foo=bar", http.NoBody)
+					So(err, ShouldBeNil)
+					rr := httptest.NewRecorder()
+					redirectProxy.Router.ServeHTTP(rr, req)
+
+					// Assert that a 308 redirect status is returned
+					So(rr.Code, ShouldEqual, http.StatusPermanentRedirect)
+
+					// Assert Redis lookup used path only
+					calls := redisClientMock.GetValueCalls()
+					So(calls, ShouldNotBeEmpty)
+					So(calls[len(calls)-1].Key, ShouldEqual, "/old-url")
+				})
+
 				Convey("When a request does not trigger a redirect", func() {
 					req, err := http.NewRequest("GET", nonRedirectURL, http.NoBody)
 					So(err, ShouldBeNil)
@@ -127,6 +142,21 @@ func TestProxyHandleRequestWithRedirect(t *testing.T) {
 
 					// Assert that a normal response (200 OK) is returned
 					So(rr.Code, ShouldEqual, http.StatusOK)
+				})
+
+				Convey("When a request does not trigger a redirect with a query string", func() {
+					req, err := http.NewRequest("GET", nonRedirectURL+"?foo=bar", http.NoBody)
+					So(err, ShouldBeNil)
+					rr := httptest.NewRecorder()
+					redirectProxy.Router.ServeHTTP(rr, req)
+
+					// Assert that a normal response (200 OK) is returned
+					So(rr.Code, ShouldEqual, http.StatusOK)
+
+					// Assert Redis lookup used path only
+					calls := redisClientMock.GetValueCalls()
+					So(calls, ShouldNotBeEmpty)
+					So(calls[len(calls)-1].Key, ShouldEqual, nonRedirectURL)
 				})
 
 				Convey("When a request is made to /health, Redis should not be contacted", func() {


### PR DESCRIPTION
### What

The proxy is currently using the full URL to string rather than just path. 

This means that using a query param will bypass the proxy, which is not intended behaviour. This corrects that.

### How to review

Check looks ok - to test you can:

- run dis-redirect-proxy
- run redis
- add redirect to redis
- send request to proxy with query param, now it gets redirected rather than forwarded to target (can see this via logs or run a separate service to not be 502d.
 
### Who can review

not me. 